### PR TITLE
HTML attribute at div implements

### DIFF
--- a/src/docfx.website.themes/default/partials/class.header.tmpl.partial
+++ b/src/docfx.website.themes/default/partials/class.header.tmpl.partial
@@ -16,7 +16,7 @@
 </div>
 {{/inClass}}
 {{#implements.0}}
-<div classs="implements">
+<div class="implements">
   <h5>{{__global.implements}}</h5>
 {{/implements.0}}
 {{#implements}}


### PR DESCRIPTION
HTML attribute class at div implements was with one "s" too much. Changed from "classs" in to "class".